### PR TITLE
FIX: set buttons' type to button in dialogs and popover

### DIFF
--- a/lib/views/components/tao_ui/components/_confirm_dialog.html.erb
+++ b/lib/views/components/tao_ui/components/_confirm_dialog.html.erb
@@ -4,8 +4,8 @@
       <%= yield if block_given? %>
     </div>
     <div class="tao-dialog-buttons">
-      <button class="button button-primary button-confirm"><%= component.confirm_text %></button>
-      <button class="button button-cancel"><%= component.cancel_text %></button>
+      <button class="button button-primary button-confirm" type="button"><%= component.confirm_text %></button>
+      <button class="button button-cancel" type="button"><%= component.cancel_text %></button>
     </div>
   </div>
 <% end %>

--- a/lib/views/components/tao_ui/components/_confirm_popover.html.erb
+++ b/lib/views/components/tao_ui/components/_confirm_popover.html.erb
@@ -4,8 +4,8 @@
       <%= yield if block_given? %>
     </div>
     <div class="tao-popover-buttons">
-      <button class="button button-small button-primary button-confirm"><%= component.confirm_text %></button>
-      <button class="button button-small button-cancel"><%= component.cancel_text %></button>
+      <button class="button button-small button-primary button-confirm" type="button"><%= component.confirm_text %></button>
+      <button class="button button-small button-cancel" type="button"><%= component.cancel_text %></button>
     </div>
   </div>
   <div class="tao-popover-arrow">

--- a/lib/views/components/tao_ui/components/_message_dialog.html.erb
+++ b/lib/views/components/tao_ui/components/_message_dialog.html.erb
@@ -4,7 +4,7 @@
       <%= yield if block_given? %>
     </div>
     <div class="tao-dialog-buttons">
-      <button class="button button-primary button-confirm"><%= component.confirm_text %></button>
+      <button class="button button-primary button-confirm" type="button"><%= component.confirm_text %></button>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
`button` 的默认 `type` 是 `submit`，如果在 `form` 中使用 `tao-popover` 或者 `tao-dialog` ，点击 `popover` 或者 `dialog` 中的按钮会触发外层 `form` 的 `submit` 行为。

Dialog 和 Popover 的中的按钮点击行为都是明确的，所以不应该有默认行为。